### PR TITLE
Default timeout in net::http is 60 seconds without this, if user does…

### DIFF
--- a/lib/client-api/settings.rb
+++ b/lib/client-api/settings.rb
@@ -27,7 +27,7 @@ module ClientApi
   end
 
   def time_out
-    ClientApi.configuration.time_out || ''
+    ClientApi.configuration.time_out || 60
   end
 
 end


### PR DESCRIPTION
…nt set the config, every request fails.